### PR TITLE
fix: maintainer param with special chars returning unexpected results

### DIFF
--- a/src/npmUsernameToPackages.test.ts
+++ b/src/npmUsernameToPackages.test.ts
@@ -74,10 +74,9 @@ describe("npmUsernameToPackages", () => {
 		expect(actual).toEqual(packageNames);
 	});
 
-	it("handle valid npm username without special characters", async () => {
+	it("handles valid npm username without special characters", async () => {
 		const packageNames = ["package1", "package2"];
 		const username = "maintainer-test";
-		const encodedUsername = encodeURIComponent(username);
 
 		mockFetch.mockResolvedValue({
 			json: () => ({
@@ -90,14 +89,13 @@ describe("npmUsernameToPackages", () => {
 
 		expect(actual).toEqual(packageNames);
 		expect(mockFetch).toHaveBeenCalledWith(
-			`https://registry.npmjs.com/-/v1/search?from=0&size=250&text=maintainer:${encodedUsername}`,
+			`https://registry.npmjs.com/-/v1/search?from=0&size=250&text=maintainer:maintainer-test`,
 			{ headers: { "Content-Type": "application/json" } },
 		);
 	});
 
-	it("handle invalid npm username with special characters", async () => {
+	it("handles invalid npm username with special characters", async () => {
 		const username = "#JI*#@%OSJ";
-		const encodedUsername = encodeURIComponent(username);
 
 		mockFetch.mockResolvedValue({
 			json: () => ({
@@ -110,7 +108,7 @@ describe("npmUsernameToPackages", () => {
 
 		expect(actual).toEqual([]);
 		expect(mockFetch).toHaveBeenCalledWith(
-			`https://registry.npmjs.com/-/v1/search?from=0&size=250&text=maintainer:${encodedUsername}`,
+			`https://registry.npmjs.com/-/v1/search?from=0&size=250&text=maintainer:%23JI*%23%40%25OSJ`,
 			{ headers: { "Content-Type": "application/json" } },
 		);
 	});

--- a/src/npmUsernameToPackages.ts
+++ b/src/npmUsernameToPackages.ts
@@ -24,11 +24,12 @@ interface ResponseBody {
 }
 
 export async function npmUsernameToPackages(maintainer: string) {
+	const encodedMaintainer = encodeURIComponent(maintainer);
 	const packages: PackageData[] = [];
 
 	while (true) {
 		const response = await fetch(
-			`https://registry.npmjs.com/-/v1/search?from=${packages.length}&size=250&text=maintainer:${maintainer}`,
+			`https://registry.npmjs.com/-/v1/search?from=${packages.length}&size=250&text=maintainer:${encodedMaintainer}`,
 			{
 				headers: { "Content-Type": "application/json" },
 			},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to npm-username-to-packages! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #291 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/npm-username-to-packages/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/npm-username-to-packages/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR fixes an issue where passing an npm username with special characters as the `maintainer` parameter causes API requests to return incorrect and unexpected results. 

To fix this, I encoded the `maintainer` parameter using `encodeURIComponent()` before appending it to the npm registry API request URL.

I also added test cases to make sure valid npm usernames and invalid npm usernames with special characters are properly handled with the new changes. Then ran `pnpm test`.

🚀